### PR TITLE
Enable to set GPIO.ALT0.

### DIFF
--- a/source/c_gpio/c_gpio.c
+++ b/source/c_gpio/c_gpio.c
@@ -148,6 +148,8 @@ setup_gpio(int gpio, int direction, int pud)
     set_pullupdn(gpio, pud);
     if (direction == OUTPUT)
         *(gpio_map+offset) = (*(gpio_map+offset) & ~(7<<shift)) | (1<<shift);
+    else if (direction == ALT0)
+        *(gpio_map+offset) = (*(gpio_map+offset) & ~(7<<shift)) | (4<<shift);
     else  // direction == INPUT
         *(gpio_map+offset) = (*(gpio_map+offset) & ~(7<<shift));
 }

--- a/source/c_gpio/py_gpio.c
+++ b/source/c_gpio/py_gpio.c
@@ -219,7 +219,7 @@ py_setup_channel(PyObject *self, PyObject *args, PyObject *kwargs)
     if (!PyArg_ParseTupleAndKeywords(args, kwargs, "ii|ii", kwlist, &channel, &direction, &pud, &initial))
         return NULL;
 
-    if (direction != INPUT && direction != OUTPUT) {
+    if (direction != INPUT && direction != OUTPUT && direction != ALT0) {
         PyErr_SetString(InvalidDirectionException, "An invalid direction was passed to setup()");
         return NULL;
     }

--- a/source/tests_gpio.py
+++ b/source/tests_gpio.py
@@ -224,6 +224,14 @@ class TestSequenceFunctions(unittest.TestCase):
 
         logging.info("ALL DONE :)")
 
+    def test7_alt0(self):
+        logging.info(" ")
+        logging.info(" ")
+        logging.info("=== ALT0 TESTS ===")
+        print(RPIO.gpio_function(5))
+        logging.info("Setting up GPIO-%s as alt0...", GPIO_OUT)
+        RPIO.setup(5, RPIO.ALT0)
+        self.assertEqual(RPIO.gpio_function(5))
 
 if __name__ == '__main__':
     logging.info("==================================")


### PR DESCRIPTION
Hi, I want to use ALT0 function by using ALT0.
So I implemented edited direction which is argument of setup_gpio, direction can be 4.
